### PR TITLE
Fixed pin on GND symbol, resolving net conflict

### DIFF
--- a/SparkFun-PowerSymbols.lbr
+++ b/SparkFun-PowerSymbols.lbr
@@ -239,7 +239,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </symbol>
 <symbol name="GND">
 <description>&lt;h3&gt;Ground Supply (Earth Ground Symbol)&lt;/h3&gt;</description>
-<pin name="3.3V" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
+<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
 <wire x1="-2.032" y1="0" x2="2.032" y2="0" width="0.254" layer="94"/>
 <wire x1="-1.27" y1="-0.762" x2="1.27" y2="-0.762" width="0.254" layer="94"/>
 <wire x1="-0.508" y1="-1.524" x2="0.508" y2="-1.524" width="0.254" layer="94"/>


### PR DESCRIPTION
The pin for the GND symbol was incorrectly marked as 3.3V, causing Eagle to automatically try to tie all GND symbols into the wrong net.